### PR TITLE
Feat/glossaries

### DIFF
--- a/test/test_glossaries.py
+++ b/test/test_glossaries.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import mock
+import re
+
+import os,sys,inspect
+currentdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+parentdir = os.path.dirname(currentdir)
+sys.path.insert(0,parentdir) 
+
+from apply_bpe import isolate_glossary, BPE
+
+class TestIsolateGlossaryFunction(unittest.TestCase):
+
+    def setUp(self):
+        self.glossary = 'like'
+
+    def _run_test_case(self, test_case):
+        orig, expected = test_case
+        out = isolate_glossary(orig, self.glossary)
+        self.assertEqual(out, expected)
+
+    def test_empty_string(self):
+        orig = ''
+        exp = ['']
+        test_case = (orig, exp)
+        self._run_test_case(test_case)
+
+    def test_no_glossary(self):
+        orig = 'word'
+        exp = ['word']
+        test_case = (orig, exp)
+        self._run_test_case(test_case)
+
+    def test_isolated_glossary(self):
+        orig = 'like'
+        exp = ['like']
+        test_case = (orig, exp)
+        self._run_test_case(test_case)
+
+    def test_isolated_glossary(self):
+        orig = 'like'
+        exp = ['like']
+        test_case = (orig, exp)
+        self._run_test_case(test_case)
+
+    def test_word_one_side(self):
+        orig = 'likeword'
+        exp = ['like', 'word']
+        test_case = (orig, exp)
+        self._run_test_case(test_case)
+
+    def test_words_both_sides(self):
+        orig = 'wordlikeword'
+        exp = ['word', 'like', 'word']
+        test_case = (orig, exp)
+        self._run_test_case(test_case)
+
+    def test_back_to_back_glossary(self):
+        orig = 'likelike'
+        exp = ['like', 'like']
+        test_case = (orig, exp)
+        self._run_test_case(test_case)
+
+    def test_multiple_glossaries(self):
+        orig = 'wordlikewordlike'
+        exp = ['word', 'like', 'word', 'like']
+        test_case = (orig, exp)
+        self._run_test_case(test_case)
+
+class TestBPEIsolateGlossariesMethod(unittest.TestCase):
+
+    def setUp(self):
+        
+        amock = mock.MagicMock()
+        amock.readline.return_value = 'something'
+        glossaries = ['like', 'Manuel', 'USA']
+        self.bpe = BPE(amock, glossaries=glossaries)
+
+    def _run_test_case(self, test_case):
+        orig, expected = test_case
+        out = self.bpe._isolate_glossaries(orig)
+        self.assertEqual(out, expected)
+
+    def test_multiple_glossaries(self):
+        orig = 'wordlikeUSAwordManuelManuelwordUSA'
+        exp = ['word', 'like', 'USA', 'word', 'Manuel', 'Manuel', 'word', 'USA']
+        test_case = (orig, exp)
+        self._run_test_case(test_case)
+
+def encode_mock(segment, x2, x3, x4, x5, x6, glosses):
+    if segment in glosses:
+        return (segment,)
+    else:
+        l = len(segment)
+        return (segment[:l/2], segment[l/2:])
+
+class TestBPESegmentMethod(unittest.TestCase):
+
+    def setUp(self):
+        
+        amock = mock.MagicMock()
+        amock.readline.return_value = 'something'
+        glossaries = ['like', 'Manuel', 'USA']
+        self.bpe = BPE(amock, glossaries=glossaries)
+
+    @mock.patch('apply_bpe.encode', side_effect=encode_mock)
+    def _run_test_case(self, test_case, encode_function):
+
+        orig, expected = test_case
+        out = self.bpe.segment(orig)
+
+        self.assertEqual(out, expected)
+
+    def test_multiple_glossaries(self):
+        orig = 'wordlikeword likeManuelword'
+        exp = 'wo@@ rd@@ like@@ wo@@ rd like@@ Manuel@@ wo@@ rd'
+        test_case = (orig, exp)
+        self._run_test_case(test_case)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add the possibility to have a list of glossaries to be "protected" from the BPE algorithm.

When applying BPE to a corpus, these glossaries will not be changed, regardless of the learnt BPE codes; they will neither be broken into subwords, nor concatenated with other subwords.

For example, given the glossary _Edinburgh_, the sentence `Edinburgh is beautiful` will always return _Edinburgh_ plus the usual BPE of the remaining sentence, which may look like:
    `Edinburgh is beauti@@ ful`

As another example, given the glossary _Google_, the sentence `GoogleNMT is more fluent than their previous model` would always separate _NMT_ from _Google_ and keep _Google_ intact.
A possible output is then:
    `Google@@ NM@@ T is more flu@@ ent than their pre@@ vious model`

An important use case for this feature is when the corpus includes special tokens that one wants to make sure are kept intact by the BPE.